### PR TITLE
change linux shared library name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Using the pthread version of OpenBLAS can cause contention, making it unstable a
 
 ```shell
 $ sudo apt install libopenblas0-openmp liblapacke
+$ sudo apt remove libopenblas0-pthread
 ```
 
 If you have already installed the pthread version of OpenBLAS, you can switch to it using the update-alternatives command.
@@ -64,6 +65,7 @@ $ sudo update-alternatives --config liblapack.so.3-x86_64-linux-gnu
 
 If you really want to use the pthread version of OpenBLAS, please switch to the serial version of rindow-matlib.
 
+There are no operational mode conflicts with OpenBLAS on Windows.
 
 And then set it up using composer.
 ```shell

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ How to download and setup
 ### Windows
 The OpenBLAS Library release number is included in the filename of the rindow-openblas pre-built archive file.
 
-- https://github.com/xianyi/OpenBLAS/releases
+- https://github.com/OpenMathLib/OpenBLAS/releases
 
 Unzip it to a suitable location and set the execution path in the bin directory.
 
@@ -47,11 +47,23 @@ C> composer require rindow/rindow-openblas-ffi
 ```
 
 ### Ubuntu
-Use the apt command to install the deb file. 
+Since rindow-matlib currently uses OpenMP, choose the OpenMP version for OpenBLAS as well.
+
+Using the pthread version of OpenBLAS can cause contention, making it unstable and slow.
 
 ```shell
-$ sudo apt install libopenblas-base liblapacke
+$ sudo apt install libopenblas0-openmp liblapacke
 ```
+
+If you have already installed the pthread version of OpenBLAS, you can switch to it using the update-alternatives command.
+
+```shell
+$ sudo update-alternatives --config libopenblas.so.0-x86_64-linux-gnu
+$ sudo update-alternatives --config liblapack.so.3-x86_64-linux-gnu
+```
+
+If you really want to use the pthread version of OpenBLAS, please switch to the serial version of rindow-matlib.
+
 
 And then set it up using composer.
 ```shell

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requirements
 ============
 
 - PHP 8.1 or PHP8.2 or PHP8.3
-- Linux or Windows
+- Windows or Linux(Ubuntu 20.04 or Debian 12 or later)
 - OpenBLAS
 
 How to download and setup

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ C> composer require rindow/rindow-openblas-ffi
 ### Ubuntu
 Since rindow-matlib currently uses OpenMP, choose the OpenMP version for OpenBLAS as well.
 
-Using the pthread version of OpenBLAS can cause contention, making it unstable and slow.
+Using the pthread version of OpenBLAS can cause conflicts and become unstable and slow.
+This issue does not occur on Windows.
+
 
 ```shell
 $ sudo apt install libopenblas0-openmp liblapacke

--- a/README.md
+++ b/README.md
@@ -46,19 +46,32 @@ C> cd \your\app\dir
 C> composer require rindow/rindow-openblas-ffi
 ```
 
-### Ubuntu
+### Linux
+Install openblas with apt command
+```shell
+$ sudo apt install libopenblas0-openmp liblapacke
+```
+
+And then set it up using composer.
+```shell
+$ mkdir \your\app\dir
+$ cd \your\app\dir
+$ composer require rindow/rindow-openblas-ffi
+```
+
+
+### Troubleshooting for Linux
 Since rindow-matlib currently uses OpenMP, choose the OpenMP version for OpenBLAS as well.
 
 Using the pthread version of OpenBLAS can cause conflicts and become unstable and slow.
 This issue does not occur on Windows.
 
-
+If you have already installed the pthread version of OpenBLAS,
 ```shell
-$ sudo apt install libopenblas0-openmp liblapacke
 $ sudo apt remove libopenblas0-pthread
 ```
 
-If you have already installed the pthread version of OpenBLAS, you can switch to it using the update-alternatives command.
+But if you can't remove it, you can switch to it using the update-alternatives command.
 
 ```shell
 $ sudo update-alternatives --config libopenblas.so.0-x86_64-linux-gnu
@@ -69,9 +82,19 @@ If you really want to use the pthread version of OpenBLAS, please switch to the 
 
 There are no operational mode conflicts with OpenBLAS on Windows.
 
-And then set it up using composer.
+But, If you really want to use the pthread version of OpenBLAS, please switch to the serial version of rindow-matlib.
+
 ```shell
-$ mkdir \your\app\dir
-$ cd \your\app\dir
-$ composer require rindow/rindow-openblas-ffi
+$ sudo update-alternatives --config librindowmatlib.so
+There are 2 choices for the alternative librindowmatlib.so (providing /usr/lib/librindowmatlib.so).
+
+  Selection    Path                                             Priority   Status
+------------------------------------------------------------
+* 0            /usr/lib/rindowmatlib-openmp/librindowmatlib.so   95        auto mode
+  1            /usr/lib/rindowmatlib-openmp/librindowmatlib.so   95        manual mode
+  2            /usr/lib/rindowmatlib-serial/librindowmatlib.so   90        manual mode
+
+Press <enter> to keep the current choice[*], or type selection number: 2
 ```
+Choose the "rindowmatlib-serial".
+

--- a/phpstan-interop.neon
+++ b/phpstan-interop.neon
@@ -1,0 +1,22 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to an undefined method Interop\\\\Polite\\\\Math\\\\Matrix\\\\.*[Device\\|Linear]*Buffer\\:\\:dtype\\(\\)#"
+		-
+			message: "#^Call to an undefined method Interop\\\\Polite\\\\Math\\\\Matrix\\\\.*[Device\\|Linear]*Buffer\\:\\:addr\\(\\)#"
+		-
+			message: "#^Call to an undefined method Interop\\\\Polite\\\\Math\\\\Matrix\\\\.*[Device\\|Linear]*Buffer\\:\\:value_size\\(\\)#"
+
+
+#		-
+#			message: "#^Call to an undefined method Interop\\\\Polite\\\\Math\\\\Matrix\\\\.*[Device\\|Linear]*Buffer\\:\\:dump\\(\\)#"
+#		-
+#			message: "#function count expects array|Countable, Interop\\\\Polite\\\\Math\\\\Matrix\\\\NDArray given#"
+#		-
+#			message: "#^Argument of an invalid type Interop\\\\Polite\\\\Math\\\\Matrix\\\\NDArray supplied for foreach, only iterables are supported#"
+#		-
+#			message: "#^Call to an undefined method Interop\\\\Polite\\\\Math\\\\Matrix\\\\DeviceBuffer\\:\\:bytes\\(\\)#"
+#		-
+#			message: "#^Call to an undefined method Interop\\\\Polite\\\\Math\\\\Matrix\\\\DeviceBuffer\\:\\:copy\\(\\)#"
+#		-
+#			message: "#^Call to an undefined method Interop\\\\Polite\\\\Math\\\\Matrix\\\\DeviceBuffer\\:\\:read\\(\\)#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+includes:
+	- phpstan-interop.neon
+	
+parameters:
+	level: 6
+	paths:
+		- src
+	ignoreErrors:
+		-
+			message: "#^Call to an undefined method FFI::#"

--- a/src/Blas.php
+++ b/src/Blas.php
@@ -26,7 +26,7 @@ class Blas
         $this->ffi = $ffi;
     }
 
-    public function getFFI()
+    public function getFFI() : FFI
     {
         return $this->ffi;
     }

--- a/src/Lapack.php
+++ b/src/Lapack.php
@@ -3,7 +3,7 @@ namespace Rindow\OpenBLAS\FFI;
 
 use Interop\Polite\Math\Matrix\NDArray;
 use InvalidArgumentException;
-
+use RuntimeException;
 use FFI;
 
 use Interop\Polite\Math\Matrix\LinearBuffer as BufferInterface;

--- a/src/Lapack.php
+++ b/src/Lapack.php
@@ -8,6 +8,11 @@ use FFI;
 
 use Interop\Polite\Math\Matrix\LinearBuffer as BufferInterface;
 
+class ffi_char_t
+{
+    public string $cdata;
+}
+
 class Lapack
 {
     use Utils;
@@ -15,7 +20,7 @@ class Lapack
     const LAPACK_WORK_MEMORY_ERROR      = -1010;
     const LAPACK_TRANSPOSE_MEMORY_ERROR = -1010;
 
-    protected $ffi;
+    protected FFI $ffi;
 
     public function __construct(FFI $ffi)
     {
@@ -89,9 +94,10 @@ class Lapack
         ) {
             throw new InvalidArgumentException("Unmatch data type", 0);
         }
-    
+        /** @var ffi_char_t $jobu_p */
         $jobu_p = $ffi->new('char');
         $jobu_p->cdata = chr($jobu);
+        /** @var ffi_char_t $jobvt_p */
         $jobvt_p = $ffi->new('char');
         $jobvt_p->cdata = chr($jobvt);
         switch ($dtype) {

--- a/src/OpenBLASFactory.php
+++ b/src/OpenBLASFactory.php
@@ -12,11 +12,19 @@ class OpenBLASFactory
 {
     private static ?FFI $ffi = null;
     private static ?FFI $ffiLapacke = null;
+    /** @var array<string> $libs_win */
     protected array $libs_win = ['libopenblas.dll'];
-    protected array $libs_linux = ['libopenblas.so.0','libopenblas.so'];
+    /** @var array<string> $libs_linux */
+    protected array $libs_linux = ['libopenblas.so.0'];
+    /** @var array<string> $lapacke_win */
     protected array $lapacke_win = ['libopenblas.dll'];
-    protected array $lapacke_linux = ['liblapacke.so.3','liblapacke.so'];
+    /** @var array<string> $lapacke_linux */
+    protected array $lapacke_linux = ['liblapacke.so.3'];
 
+    /**
+     * @param array<string> $libFiles
+     * @param array<string> $lapackeLibs
+     */
     public function __construct(
         string $headerFile=null,
         array $libFiles=null,

--- a/src/OpenBLASFactory.php
+++ b/src/OpenBLASFactory.php
@@ -13,9 +13,9 @@ class OpenBLASFactory
     private static ?FFI $ffi = null;
     private static ?FFI $ffiLapacke = null;
     protected array $libs_win = ['libopenblas.dll'];
-    protected array $libs_linux = ['libopenblas.so','libopenblas.so.0'];
+    protected array $libs_linux = ['libopenblas.so.0','libopenblas.so'];
     protected array $lapacke_win = ['libopenblas.dll'];
-    protected array $lapacke_linux = ['liblapacke.so','liblapacke.so.3'];
+    protected array $lapacke_linux = ['liblapacke.so.3','liblapacke.so'];
 
     public function __construct(
         string $headerFile=null,

--- a/tests/RindowTest/OpenBLAS/FFI/Utils.php
+++ b/tests/RindowTest/OpenBLAS/FFI/Utils.php
@@ -3,7 +3,7 @@ namespace RindowTest\OpenBLAS\FFI;
 
 use Interop\Polite\Math\Matrix\NDArray;
 use Interop\Polite\Math\Matrix\BLAS;
-use ArrayAccess;
+use Interop\Polite\Math\Matrix\Buffer as BufferInterface;
 use ArrayObject;
 use InvalidArgumentException;
 use Rindow\Math\Buffer\FFI\Buffer;
@@ -186,7 +186,7 @@ trait Utils
         
             public function dtype() { return $this->dtype; }
         
-            public function buffer() : ArrayAccess { return $this->buffer; }
+            public function buffer() : BufferInterface { return $this->buffer; }
         
             public function offset() : int { return $this->offset; }
         


### PR DESCRIPTION
- I decided to use openmp to avoid conflicts between openblas and rindow-matlib.
- The Readme has been changed in accordance with the policy change.
- Fixed the openblas shared library file names to libopenblas.so.0 and liblapacke.so.3 to simplify the procedure for switching with the pthead version.
- Standardized type declarations using phpstan.
